### PR TITLE
README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Go bindings for the Brotli compression library
 ===
 
-See https://github.com/google/brotli for the upstream C/C++ source
+See <https://github.com/google/brotli> for the upstream C/C++ source
 
 Usage
 ---
@@ -9,15 +9,16 @@ Usage
 To use the bindings, you just need to import the enc or dec package and call the Go wrapper 
 functions `enc.CompressBuffer` or `dec.DecompressBuffer`
 
-~~~
+```go
 import (
 	"gopkg.in/kothar/brotli-go.v0/dec"
 	"gopkg.in/kothar/brotli-go.v0/enc"
 )
-~~~
+```
 
 From the tests:
-~~~
+
+```go
 import (
 	"bytes"
 	"testing"
@@ -52,7 +53,7 @@ func TestRoundtrip(T *testing.T) {
 		T.Log("Decoded output matches original input")
 	}
 }
-~~~
+```
 
 Bindings
 ---
@@ -62,13 +63,13 @@ things working with Go.
 
 1. The default dictionary has been extracted to a separate 'shared' package to allow linking the enc and dec cgo modules if you use both. Otherwise there are duplicate symbols, as described in the dictionary.h header files.
 
-2. The dictonary variable name for the dec package has been modified for the same reason, to avoid linker collisions.
+2. The dictionary variable name for the dec package has been modified for the same reason, to avoid linker collisions.
 
 TODO
 ---
 
 * I haven't implemented stream compression yet - it will need a wrapper for the C++ classes. For a stream decompression implementation, please take a look at
-https://github.com/dsnet/compress
+<https://github.com/dsnet/compress>
 
 License
 ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Go bindings for the Brotli compression library
 
+[![GoDoc](https://godoc.org/gopkg.in/kothar/brotli-go.v0?status.svg)](https://godoc.org/gopkg.in/kothar/brotli-go.v0)
+[![Build Status](https://travis-ci.org/kothar/brotli-go.svg)](https://travis-ci.org/kothar/brotli-go)
+
 See <https://github.com/google/brotli> for the upstream C/C++ source, and
 the `VERSION.md` file to find out the currently vendored version.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-Go bindings for the Brotli compression library
-===
+# Go bindings for the Brotli compression library
 
-See <https://github.com/google/brotli> for the upstream C/C++ source
+See <https://github.com/google/brotli> for the upstream C/C++ source, and
+the `VERSION.md` file to find out the currently vendored version.
 
 Usage
 ---
 
-To use the bindings, you just need to import the enc or dec package and call the Go wrapper 
+To use the bindings, you just need to import the enc or dec package and call the Go wrapper
 functions `enc.CompressBuffer` or `dec.DecompressBuffer`
 
 ```go
@@ -55,6 +55,53 @@ func TestRoundtrip(T *testing.T) {
 }
 ```
 
+Advanced usage (streaming API)
+---
+
+When the data set is too large to fit in-memory, `CompressBuffer` and
+`DecompressBuffer` are not a viable option.
+
+`brotli-go` also exposes a streaming interface both for encoding:
+
+```go
+import (
+	"gopkg.in/kothar/brotli-go.v0/enc"
+)
+
+func main() {
+  compressedWriter := os.OpenFile("data.bin.bro", os.O_CREATE|os.O_WRONLY, 0644)
+
+  // passing nil to get default params — careful, q=11 is the (extremely slow) default
+  brotliWriter := enc.NewBrotliWriter(nil, compressedWriter)
+  // BrotliWriter will close writer passed as argument if it implements io.Closer
+  defer brotliWriter.Close()
+
+  fileReader, _ := os.Open("data.bin")
+  defer fileReader.Close()
+
+  io.Copy(fileReader, brotliWriter)
+}
+```
+
+..and for decoding:
+
+```go
+import (
+	"gopkg.in/kothar/brotli-go.v0/dec"
+)
+
+func main() {
+  archiveReader, _ := os.Open("data.bin.bro")
+
+  brotliReader := dec.NewBrotliReader(archiveReader)
+  defer brotliReader.Close()
+
+  decompressedWriter := os.OpenFile("data.bin.unbro", os.O_CREATE|os.O_WRONLY, 0644)
+  defer decompressedWriter.Close()
+  io.Copy(brotliReader, decompressedWriter)
+}
+```
+
 Bindings
 ---
 
@@ -65,11 +112,10 @@ things working with Go.
 
 2. The dictionary variable name for the dec package has been modified for the same reason, to avoid linker collisions.
 
-TODO
+Links
 ---
 
-* I haven't implemented stream compression yet - it will need a wrapper for the C++ classes. For a stream decompression implementation, please take a look at
-<https://github.com/dsnet/compress>
+  * brotli streaming decompression written in pure go: <https://github.com/dsnet/compress>
 
 License
 ---


### PR DESCRIPTION
In this PR:

  * :trophy: badges for both godoc & travis
  * Simpler examples (with a reference to the full test case)
  * A note about `VERSION.md`
  * Syntax highlighting for code samples
  * Minor markdown syntax pet peeves (autolink is a Github-Flavored Markdown extension,  for example)

Note that #6, #7 and #8 are blockers for this :)