### PR TITLE
Fix bugs with streaming Reader

### DIFF
--- a/dec/decode_test.go
+++ b/dec/decode_test.go
@@ -2,6 +2,7 @@ package dec
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"gopkg.in/kothar/brotli-go.v0/enc"
@@ -24,7 +25,7 @@ func TestStreamDecompression(T *testing.T) {
 	reader := NewBrotliReader(bytes.NewReader(output1))
 	decoded := make([]byte, len(input1))
 
-	read, err := reader.Read(decoded)
+	read, err := io.ReadFull(reader, decoded)
 	if err != nil {
 		T.Fatal(err)
 	}


### PR DESCRIPTION
* If the return code is BROTLI_RESULT_NEEDS_MORE_OUTPUT, we do not need to fill
the input buffer again. Otherwise, we risk premature termination since we hit
io.EOF in the underlying Reader first.
* We must check that the input buffer is not empty. Otherwise dereference of
&p[0] will panic.
* We must convert an io.EOF received from the underlying Reader into an
io.ErrUnexpectedEOF. The only valid EOF condition is when the decompressor tells
us so with a BROTLI_RESULT_SUCCESS code.
* Brotli documentation does not guarantee that calling BrotliStateCleanup twice
is okay. Thus, the use of a Finalizer or the fact that someone may call Close
multiple times is not okay.
* Reader errors should persist across multiple Read calls.
* Close should not close the underlying Reader. I don't know of any standard
library Reader that does this. Most certainly the compression library do not
do this.
* After Close, it should be invalid to call Read.