### PR TITLE
#import is a GCC extension, include guards are sufficient

### DIFF
--- a/shared/shared.go
+++ b/shared/shared.go
@@ -3,7 +3,7 @@
 package shared
 
 /*
-#import "dictionary.h"
+#include "dictionary.h"
 */
 import "C"
 


### PR DESCRIPTION
cf. [this travis log on linux/amd64](https://travis-ci.org/itchio/brotli-go/jobs/92036672#L136)