### PR TITLE
Closes #35: avoid index out of range when decompressor needs input an…

### DIFF
--- a/dec/decode.go
+++ b/dec/decode.go
@@ -136,9 +136,13 @@ func (r *BrotliReader) Read(p []byte) (n int, err error) {
 		if r.availableIn > 0 || r.needOutput {
 			// Decompress
 			inputPosition := r.bufferRead - int(r.availableIn)
+			nextIn := unsafe.Pointer(uintptr(0))
+			if r.availableIn > 0 {
+				nextIn = unsafe.Pointer(&r.buffer[inputPosition])
+			}
 			result := C.BrotliDecompressStream_Wrapper(
 				&r.availableIn,
-				(*C.uint8_t)(unsafe.Pointer(&r.buffer[inputPosition])),
+				(*C.uint8_t)(nextIn),
 				&availableOut,
 				(*C.uint8_t)(unsafe.Pointer(&p[0])),
 				&r.totalOut,

--- a/dec/decode.go
+++ b/dec/decode.go
@@ -136,7 +136,7 @@ func (r *BrotliReader) Read(p []byte) (n int, err error) {
 		if r.availableIn > 0 || r.needOutput {
 			// Decompress
 			inputPosition := r.bufferRead - int(r.availableIn)
-			nextIn := unsafe.Pointer(uintptr(0))
+			nextIn := unsafe.Pointer(nil)
 			if r.availableIn > 0 {
 				nextIn = unsafe.Pointer(&r.buffer[inputPosition])
 			}


### PR DESCRIPTION
…d we have no input available

See #35 for more details on the issue.